### PR TITLE
Wrap the Jami binary in a launcher script that manually starts `dring`

### DIFF
--- a/jami-gnome-wrapper
+++ b/jami-gnome-wrapper
@@ -1,0 +1,6 @@
+#!/bin/sh
+# The ring deamon should be launched automatically, but some Flatpak change
+# started preventing it from installing its service activation file
+dring &
+
+exec jami-gnome "$@"

--- a/net.jami.Jami.json
+++ b/net.jami.Jami.json
@@ -3,7 +3,7 @@
 	"runtime": "org.gnome.Platform",
 	"runtime-version": "3.36",
 	"sdk": "org.gnome.Sdk",
-	"command": "jami-gnome",
+	"command": "jami-gnome-wrapper",
 	"finish-args": [
 		"--socket=x11",
 		"--socket=wayland",
@@ -77,6 +77,21 @@
 				"org.fukuchi.qrencode.json",
 				"libayatana-appindicator.json",
 				"jami-deps-contrib/_.json"
+			]
+		},
+
+		{
+			"name": "install-launch-wrapper",
+			"buildsystem": "simple",
+			"build-commands": [
+				"cp jami-gnome-wrapper \"${FLATPAK_DEST}/bin/\"",
+				"sed -i 's/Exec=jami-gnome/Exec=jami-gnome-wrapper/g' \"${FLATPAK_DEST}/share/applications/jami-gnome.desktop\""
+			],
+			"sources": [
+				{
+					"type": "file",
+					"path": "jami-gnome-wrapper"
+				}
 			]
 		}
 	]

--- a/net.jami.Jami_dev.json
+++ b/net.jami.Jami_dev.json
@@ -5,7 +5,7 @@
 	"runtime": "org.gnome.Platform",
 	"runtime-version": "3.36",
 	"sdk": "org.gnome.Sdk",
-	"command": "jami-gnome",
+	"command": "jami-gnome-wrapper",
 	"finish-args": [
 		"--socket=x11",
 		"--socket=wayland",
@@ -120,6 +120,21 @@
 			"cleanup": [
 				"/bin/jami",
 				"/bin/ring.cx"
+			]
+		},
+
+		{
+			"name": "install-launch-wrapper",
+			"buildsystem": "simple",
+			"build-commands": [
+				"cp jami-gnome-wrapper \"${FLATPAK_DEST}/bin/\"",
+				"sed -i 's/Exec=jami-gnome/Exec=jami-gnome-wrapper/g' \"${FLATPAK_DEST}/share/applications/jami-gnome.desktop\""
+			],
+			"sources": [
+				{
+					"type": "file",
+					"path": "jami-gnome-wrapper"
+				}
 			]
 		}
 	]


### PR DESCRIPTION
Should hopefully fix the issues people are having.