### PR TITLE
disable wayland and more

### DIFF
--- a/dependencies/jami-daemon.yml
+++ b/dependencies/jami-daemon.yml
@@ -12,7 +12,7 @@ build-commands:
 sources:
   - type: git
     url: https://git.jami.net/savoirfairelinux/ring-daemon.git
-    commit: 3eede614a445f73633e439d5240077c391a65423
+    commit: 51149184dda6552be6d92b3fe66c8d72327a6326
   - type: file
     url: https://github.com/pjsip/pjproject/archive/2.10/pjproject-2.10.tar.gz
     sha256: 936a4c5b98601b52325463a397ddf11ab4106c6a7b04f8dc7cdd377efbb597de

--- a/dependencies/libringclient.yml
+++ b/dependencies/libringclient.yml
@@ -9,4 +9,4 @@ config-opts:
 sources:
   - type: git
     url: https://git.jami.net/savoirfairelinux/ring-lrc.git
-    commit: 570ed62f6bb93f82f1ed28f1089e5604393902f6
+    commit: 3443dc6630d3efc062f1140b1806ea21f115668b

--- a/net.jami.Jami.yml
+++ b/net.jami.Jami.yml
@@ -15,9 +15,6 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
   #- --talk-name=org.gtk.vfs    # seems to work without it
   #- --talk-name=org.gtk.vfs.*
-  - --filesystem=~/.local/share/ring
-  - --filesystem=~/.local/share/gnome-ring
-  - --filesystem=xdg-config/ring
   - --filesystem=xdg-download
   - --filesystem=xdg-music
   - --filesystem=xdg-pictures

--- a/net.jami.Jami.yml
+++ b/net.jami.Jami.yml
@@ -6,8 +6,8 @@ command: jami-gnome
 
 finish-args:
   - --share=ipc
-  - --socket=fallback-x11
-  - --socket=wayland
+  - --socket=x11
+  #- --socket=wayland
   - --socket=pulseaudio
   - --share=network
   - --device=all

--- a/net.jami.Jami.yml
+++ b/net.jami.Jami.yml
@@ -58,7 +58,7 @@ modules:
     sources:
       - type: git
         url: https://git.jami.net/savoirfairelinux/ring-client-gnome.git
-        commit: f6d50ba8bd027d9d02964f0954b40275c472267b
+        commit: 7695511b3526e91cf98ef0ff5f8fc39a42442982
       - type: patch
         path: patches/jami-gnome_client-appstream-metadata.patch
       - type: shell

--- a/patches/jami-gnome_client-appstream-metadata.patch
+++ b/patches/jami-gnome_client-appstream-metadata.patch
@@ -8,7 +8,7 @@ index aced5b3..8ebfeca 100644
   <summary>Privacy oriented voice, video and chat platform.</summary>
 - <icon type="stock">jami</icon>
 + <releases>
-+  <release version="20210104.1.f6d50ba8" date="2021-01-04" />
++  <release version="20210111.1.7695511b" date="2021-01-11" />
 + </releases>
   <description>
    <p>


### PR DESCRIPTION
- Clutter doesn't support xdg-shell ergo no wayland.
- Some fs permissions for config sharing are removed because jami doesn't use them anymore and it is discouraged anyway.
- update the Jamis