### PR TITLE
Update to stable/20251106.0

### DIFF
--- a/dependencies/dhtnet.yml
+++ b/dependencies/dhtnet.yml
@@ -12,5 +12,5 @@ config-opts:
 sources:
   - type: git
     url: https://git.jami.net/savoirfairelinux/dhtnet.git
-    commit: 7861b4620b4cec5fa34c5d1bb2b304912730f638
+    commit: f925f5200539d4e1ee6176d828ae08a8a6c3890a
     disable-submodules: true

--- a/dependencies/ffmpeg.yml
+++ b/dependencies/ffmpeg.yml
@@ -210,8 +210,8 @@ config-opts:
 
 sources:
   - type: archive
-    url: https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n6.0.1.tar.gz
-    sha256: 98cb563487d6a652067bfb12a4b4f7fb533fc93e278f6a1821008c0b864c387f
+    url: https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n6.1.3.tar.gz
+    sha256: 1c2eb1f4ab88c1d6797c8cd3ef48137169eb913417a41fb965a0d08ef52a2714
   - type: patch
     path: ../patches/ffmpeg-patches/screen-sharing-x11-fix.patch
   - type: patch

--- a/dependencies/ffnvcodec.yml
+++ b/dependencies/ffnvcodec.yml
@@ -4,5 +4,5 @@ make-install-args:
   - PREFIX=/app
 sources:
   - type: archive
-    url: https://github.com/FFmpeg/nv-codec-headers/releases/download/n11.1.5.2/nv-codec-headers-11.1.5.2.tar.gz
-    sha256: 1442e3159e7311dd71f8fca86e615f51609998939b6a6d405d6683d8eb3af6ee
+    url: https://github.com/FFmpeg/nv-codec-headers/releases/download/n13.0.19.0/nv-codec-headers-13.0.19.0.tar.gz
+    sha256: 13da39edb3a40ed9713ae390ca89faa2f1202c9dda869ef306a8d4383e242bee

--- a/dependencies/opendht.yml
+++ b/dependencies/opendht.yml
@@ -14,5 +14,5 @@ config-opts:
   - -DOPENDHT_TOOLS=Off
 sources:
   - type: archive
-    url: https://github.com/savoirfairelinux/opendht/archive/refs/tags/v3.5.4rc3.tar.gz
-    sha256: 32cf80c82791c3be5fa887872e2b4dfc82274012e464a4f445c1a4ee444d802e
+    url: https://github.com/savoirfairelinux/opendht/archive/refs/tags/v3.5.5rc1.tar.gz
+    sha256: 2535419d2ba3db6ae89192e4026c06c2fd60bb9911f17e687381693577aeafdd

--- a/dependencies/yaml-cpp.yml
+++ b/dependencies/yaml-cpp.yml
@@ -7,6 +7,6 @@ config-opts:
   - -DYAML_CPP_BUILD_TESTS=OFF
   - -DYAML_CPP_BUILD_CONTRIB=OFF
 sources:
-  - type: archive
-    url: https://github.com/jbeder/yaml-cpp/archive/refs/tags/0.8.0.tar.gz
-    sha256: fbe74bbdcee21d656715688706da3c8becfd946d92cd44705cc6098bb23b3a16
+  - type: git
+    url: https://github.com/jbeder/yaml-cpp.git
+    commit: a83cd31548b19d50f3f983b069dceb4f4d50756d

--- a/net.jami.Jami.yml
+++ b/net.jami.Jami.yml
@@ -78,7 +78,7 @@ modules:
     sources:
       - type: git
         url: https://git.jami.net/savoirfairelinux/jami-client-qt
-        tag: stable/20251003.0
+        commit: nightly/20251106.0
       - type: patch
         path: patches/jami-client-qt-patches/jami-daemon_replace-static.patch
       - type: patch

--- a/patches/jami-client-qt-patches/jami-client-qt_fix-build.patch
+++ b/patches/jami-client-qt-patches/jami-client-qt_fix-build.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 29bfde9acc..826c04a86d 100644
+index bf8d239a..57ba08de 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -71,13 +71,6 @@ set(CLIENT_LIBS, "")
@@ -25,7 +25,7 @@ index 29bfde9acc..826c04a86d 100644
 -endif()
 +find_package(QWindowKit REQUIRED)
  
--# If qwindowkit can't find qmsetup via cmake's find_package function, it will install it and
+-# If qwindowkit is unable to find qmsetup via cmake's find_package function, it will install it and
 -# then call find_package again. Unfortunately, even the second call to find_package sometimes
 -# fails due to qmsetup having been installed in the wrong directory. The following patch
 -# ensures that qmsetup is always installed in the directory where find_package looks for it.

--- a/patches/jami-client-qt-patches/jami-daemon_replace-static.patch
+++ b/patches/jami-client-qt-patches/jami-daemon_replace-static.patch
@@ -1,5 +1,5 @@
 diff --git a/daemon/CMakeLists.txt b/daemon/CMakeLists.txt
-index 42c30a5ea..ea64a8093 100644
+index a4c01b3ab..b3e5d68be 100644
 --- a/daemon/CMakeLists.txt
 +++ b/daemon/CMakeLists.txt
 @@ -236,6 +236,7 @@ if(NOT MSVC)
@@ -18,7 +18,7 @@ index 42c30a5ea..ea64a8093 100644
  )
  if (JAMI_VIDEO)
      target_compile_definitions(${PROJECT_NAME} PRIVATE ENABLE_VIDEO)
-@@ -684,7 +686,7 @@ else()
+@@ -686,7 +688,7 @@ else()
          target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::udev)
          if (pulseaudio_FOUND)
              target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_PULSE)


### PR DESCRIPTION
**NOTE:** The tag used for this build is nightly/20251106.0 but it should be noted that both nightly/20251106.0 and stable/20251106.0 correspond to the same commit in the jami-client-qt repo.
**Dependencies updated:**
_DHTNet:_ 7861b4620b4cec5fa34c5d1bb2b304912730f -> f925f5200539d4e1ee6176d828ae08a8a6c38
_FFMPEG:_ 6.0.1 -> 6.1.3
_FFNVCODEC:_ 11.1.5.2 -> 13.0.19.0
_OPENDHT:_  3.5.4rc3 -> 3.5.5rc1
_YAML_: 0.8.0 -> (commit) a83cd31548b19d50f3f983b069dceb4f4d50756d